### PR TITLE
Add Pk for cobaya wrapper

### DIFF
--- a/cosmopower/wrappers/cobaya/cosmopower.py
+++ b/cosmopower/wrappers/cobaya/cosmopower.py
@@ -198,7 +198,10 @@ class CosmoPower(BoltzmannBase):
                     data[iz] = get_data(used_params)[0, :]
 
                 state["z"] = self.pk_redshifts
-                state[('Pk_grid', True, 'delta_tot', 'delta_tot')] = data / params['h']**3.
+                if quantity.split('/')[1] == 'lin':
+                    state[('Pk_grid', False, 'delta_tot', 'delta_tot')] = data / params['h']**3.
+                elif quantity.split('/')[1] == 'nonlin':
+                    state[('Pk_grid', True, 'delta_tot', 'delta_tot')] = data / params['h']**3.
 
             else:
                 data = get_data(used_params)[0, :]

--- a/cosmopower/wrappers/cobaya/cosmopower.py
+++ b/cosmopower/wrappers/cobaya/cosmopower.py
@@ -38,6 +38,9 @@ class CosmoPower(BoltzmannBase):
         for nw in self._networks:
             self._params_required_by_networks.update({str(p) : None for p in self._networks[nw].parameters})
 
+        # z is a special case (not actually a sampled parameter)
+        del(self._params_required_by_networks['z'])
+
     def must_provide(self, **requirements: dict) -> dict:
         super().must_provide(**requirements)
 
@@ -51,6 +54,16 @@ class CosmoPower(BoltzmannBase):
             if k == "Cl":
                 for a in v:
                     required_quantities.append(f"Cl/{a.lower()}")
+
+            elif "Pk_interpolator" in requirements.keys():
+                v = self._must_provide[('Pk_grid', True, 'delta_tot', 'delta_tot')]
+                self.pk_redshifts = v.pop("z")
+                self.pk_k_max = v.pop("k_max")
+                self.pk_nonlin = v.pop("nonlinear", True)
+                if self.pk_nonlin:
+                    required_quantities.append("Pk/nonlin")
+                else:
+                    required_quantities.append("Pk/lin")
             else:
                 required_quantities.append(f"{k}" if v is not None else k)
 
@@ -114,6 +127,9 @@ class CosmoPower(BoltzmannBase):
 
         self.log.debug(f"Will evaluate networks {self._networks_to_eval}")
 
+        # z is a special case (not actually a sampled parameter)
+        del(must_provide['z'])
+
         return must_provide
 
     def calculate(self, state: dict, want_derived: bool = True,
@@ -155,12 +171,44 @@ class CosmoPower(BoltzmannBase):
 
             network = self.networks[quantity]
 
-            used_params = {p: input_params[p] for p in network.parameters}
+            # if 'z' in network.parameters:
+            #     input_params['z'] = np.asarray(self.pk_redshifts)
+
+            # used_params = {p: input_params[p] for p in network.parameters}
+
+            used_params = {}
+
+            for p in network.parameters:
+                if p == 'z':
+                    continue # 'z' is treated as an emulated but not sampled parameter
+                else:
+                    used_params[p] = input_params[p]
 
             if self.parser.is_log(quantity):
-                data = network.ten_to_predictions_np(used_params)[0, :]
+                get_data = network.ten_to_predictions_np
             else:
-                data = network.predictions_np(used_params)[0, :]
+                get_data = network.predictions_np
+
+            if 'z' in network.parameters:
+
+                data = np.empty([len(np.asarray(self.pk_redshifts)), len(network.modes)])
+
+                for iz, z_eval in enumerate(self.pk_redshifts):
+                    used_params = {**used_params, **{'z': z_eval}}
+                    data[iz] = get_data(used_params)[0, :]
+
+                state["z"] = self.pk_redshifts
+                state[('Pk_grid', True, 'delta_tot', 'delta_tot')] = data
+
+            else:
+                data = get_data(used_params)[0, :]
+
+            import pdb; pdb.set_trace()
+
+            # if self.parser.is_log(quantity):
+            #     data = network.ten_to_predictions_np(used_params)[0, :]
+            # else:
+            #     data = network.predictions_np(used_params)[0, :]
 
             self.set_in_dict(state, quantity, data)
             if self.parser.modes_label(quantity) == "l":
@@ -253,6 +301,14 @@ class CosmoPower(BoltzmannBase):
         raise LoggedError(self.log, "Need either fsigma8(z) or sigma8(z) to \
                                      compute fsigma8, but neither are \
                                      computed.")
+
+    def get_Pk_grid(self, var_pair=("delta_tot", "delta_tot"), nonlinear=True):
+
+        k = self.current_state["k"]
+        z = self.current_state["z"]
+        Pk = self.current_state[('Pk_grid', True, 'delta_tot', 'delta_tot')]
+
+        return k, z, Pk
 
     def get_Cl(self, ell_factor: bool = False,
                units: str = "FIRASmuK2") -> dict:

--- a/cosmopower/wrappers/cobaya/cosmopower.py
+++ b/cosmopower/wrappers/cobaya/cosmopower.py
@@ -198,12 +198,10 @@ class CosmoPower(BoltzmannBase):
                     data[iz] = get_data(used_params)[0, :]
 
                 state["z"] = self.pk_redshifts
-                state[('Pk_grid', True, 'delta_tot', 'delta_tot')] = data
+                state[('Pk_grid', True, 'delta_tot', 'delta_tot')] = data / params['h']**3.
 
             else:
                 data = get_data(used_params)[0, :]
-
-            import pdb; pdb.set_trace()
 
             # if self.parser.is_log(quantity):
             #     data = network.ten_to_predictions_np(used_params)[0, :]

--- a/demos/demo_desy1clustering.yaml
+++ b/demos/demo_desy1clustering.yaml
@@ -1,6 +1,6 @@
 # Set the location for the sampler outputs
 # (samples, restart, progress files etc).
-output: output/demo_3x2pt
+output: output/demo_desy1clustering_cosmopower
 
 # Set the parameter ranges and priors to sample over
 params:
@@ -9,13 +9,13 @@ params:
   logT_AGN: 7.8
   ombh2:
     prior:
-      min: 0.01
-      max: 0.05
+      min: 0.015
+      max: 0.03
     ref: 0.0225
   omch2:
     prior:
-      min: 0.01
-      max: 0.90
+      min: 0.09
+      max: 0.15
     ref: 0.120
   omegam:
     value: "lambda omch2, ombh2, h: (ombh2 + omch2)/(h*h)"
@@ -28,15 +28,15 @@ params:
     value: "lambda h: 100.0 * h"
   logA:
     prior:
-      min: 2.0
-      max: 4.0
+      min: 2.5
+      max: 3.5
     ref: 3.05
   As:
     value: "lambda logA: 1e-10 * np.exp(logA)"
   ns:
     prior:
-      min: 0.8
-      max: 1.2
+      min: 0.85
+      max: 1.05
     ref: 0.97
   DES_DzL1: 0.0
   DES_DzL2: 0.0
@@ -48,6 +48,17 @@ params:
   DES_b3: 1.65
   DES_b4: 1.8
   DES_b5: 2.0
+  DES_DzS1: 0.0
+  DES_DzS2: 0.0
+  DES_DzS3: 0.0
+  DES_DzS4: 0.0
+  DES_m1: 0.0
+  DES_m2: 0.0
+  DES_m3: 0.0
+  DES_m4: 0.0
+  DES_AIA: 1.
+  DES_alphaIA: 1.
+  DES_z0IA: 0.62
 
 
 # Add an extra prior e.g. this one on tau.
@@ -58,8 +69,9 @@ priors:
 # For testing use evaluate (likelihood calculated at one reference point).
 # Otherwise mcmc.
 sampler:
-  # mcmc:
-  evaluate:
+  mcmc:
+    covmat: output/demo_desy1clustering_camb.covmat
+  # evaluate:
 
 
 # Specify the Theory components to use. Here we use cosmpower for the Cl observables
@@ -87,5 +99,5 @@ theory:
 likelihood:
   # planck_2018_highl_plik.TTTEEE_lite_native:
   #   stop_at_error: True
-  des_y1.clustering:
+  des_y1.joint:
     l_max: 2000

--- a/demos/demo_desy1clustering.yaml
+++ b/demos/demo_desy1clustering.yaml
@@ -1,0 +1,91 @@
+# Set the location for the sampler outputs
+# (samples, restart, progress files etc).
+output: output/demo_3x2pt
+
+# Set the parameter ranges and priors to sample over
+params:
+  A_b: 3.13
+  eta_b: 0.603
+  logT_AGN: 7.8
+  ombh2:
+    prior:
+      min: 0.01
+      max: 0.05
+    ref: 0.0225
+  omch2:
+    prior:
+      min: 0.01
+      max: 0.90
+    ref: 0.120
+  omegam:
+    value: "lambda omch2, ombh2, h: (ombh2 + omch2)/(h*h)"
+  h:
+    prior:
+      min: 0.4
+      max: 1.0
+    ref: 0.7
+  H0:
+    value: "lambda h: 100.0 * h"
+  logA:
+    prior:
+      min: 2.0
+      max: 4.0
+    ref: 3.05
+  As:
+    value: "lambda logA: 1e-10 * np.exp(logA)"
+  ns:
+    prior:
+      min: 0.8
+      max: 1.2
+    ref: 0.97
+  DES_DzL1: 0.0
+  DES_DzL2: 0.0
+  DES_DzL3: 0.0
+  DES_DzL4: 0.0
+  DES_DzL5: 0.0
+  DES_b1: 1.45
+  DES_b2: 1.55
+  DES_b3: 1.65
+  DES_b4: 1.8
+  DES_b5: 2.0
+
+
+# Add an extra prior e.g. this one on tau.
+priors:
+  tau_prior: "stats.norm.logpdf(tau, loc = 6.7e-2, scale = 2.3e-2)"
+
+
+# For testing use evaluate (likelihood calculated at one reference point).
+# Otherwise mcmc.
+sampler:
+  # mcmc:
+  evaluate:
+
+
+# Specify the Theory components to use. Here we use cosmpower for the Cl observables
+# but run normal CAMB in the background-only mode (which is fast) for background observables.
+# Note we use the 'provides' key within each theory, to specify which observables come from where
+# (in some cases observables can be available from more than one Theory).
+theory:
+  cosmopower:
+    package_file: ../cosmopower-organization/jense_2024_emulators/jense_2023_pk_camb_lcdm.yaml
+    root_dir: ../cosmopower-organization/jense_2024_emulators/
+    provides:
+      Pk_interpolator:
+  camb:
+    provides: # Force cobaya to use the camb-calculated versions of these
+      angular_diameter_distance:
+      comoving_radial_distance:
+      Hubble:
+      # If you wish to verify against native camb, turn this on and turn off cosmopower
+      # You will also need to turn off the three baryon feedback model parameters above
+      # (A_b, eta_b, logT_AGN)
+      # Pk_interpolator:
+
+
+# Include a BAO and CMB TTTEEE likelihood
+likelihood:
+  # planck_2018_highl_plik.TTTEEE_lite_native:
+  #   stop_at_error: True
+  des_y1.clustering:
+    l_max: 2000

--- a/demos/demo_desy1joint.yaml
+++ b/demos/demo_desy1joint.yaml
@@ -1,6 +1,6 @@
 # Set the location for the sampler outputs
 # (samples, restart, progress files etc).
-output: output/demo_desy1clustering_cosmopower
+output: output/demo_desy1joint_cosmopower
 
 # Set the parameter ranges and priors to sample over
 params:


### PR DESCRIPTION
Just a draft PR to begin with... At the moment this is written in a very kludgy way which assumes only a `Pk_interpolator` requirement from a likelihood and deals with it in a very non-Cobaya-type way (cf the very different way `must_provide` is written in `BoltzmannBase`).